### PR TITLE
feat: specify ITS params for XRPL

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,2 +1,0 @@
-PRIVATE_KEY = '0x...'
-ENV = 'testnet'

--- a/.example.env
+++ b/.example.env
@@ -1,0 +1,2 @@
+PRIVATE_KEY = '0x...'
+ENV = 'testnet'

--- a/axelar-chains-config/info/stagenet.json
+++ b/axelar-chains-config/info/stagenet.json
@@ -2406,6 +2406,10 @@
           "maxUintBits": 127,
           "maxDecimalsWhenTruncating": 255
         },
+        "xrpl": {
+          "maxUintBits": 256,
+          "maxDecimalsWhenTruncating": 255
+        },
         "lastUploadedCodeId": 29
       },
       "AxelarnetGateway": {


### PR DESCRIPTION
Specify `maxUintBits` and `maxDecimalsWhenTruncating` for `xrpl` in Stagenet chain config. This was to be able to submit a chain registration of ITS Hub for the XRPL.